### PR TITLE
Compute signature for each API HTTP request

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+# https://github.com/bbatsov/ruby-style-guide
+# https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+# http://relaxed.ruby.style/
+
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.4
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,15 +14,21 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    ast (2.4.0)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    faraday (0.13.1)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    i18n (0.9.1)
+    i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     multipart-post (2.0.0)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
+    powerpack (0.1.1)
+    rainbow (3.0.0)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -37,9 +43,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
@@ -49,6 +64,7 @@ DEPENDENCIES
   bundler (~> 1.16.a)
   rake (~> 10.0)
   rspec (~> 3.0)
+  rubocop
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.1

--- a/arbol_financiero.gemspec
+++ b/arbol_financiero.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16.a"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop"
   spec.add_dependency "faraday"
   spec.add_dependency "json"
   spec.add_dependency "activesupport"

--- a/lib/arbol_financiero.rb
+++ b/lib/arbol_financiero.rb
@@ -26,7 +26,7 @@ module ArbolFinanciero
     attr_accessor :api_base, :api_version, :connection, :api_key, :secret_key
 
     def initialize
-      @api_base = 'https://solicitud.laudex.mx/api'
+      @api_base = 'http://www.arbolfinanciero.com/api'
       @api_version = 'v1'
       @connection = Faraday.new
       @api_key = nil

--- a/lib/arbol_financiero/requestor.rb
+++ b/lib/arbol_financiero/requestor.rb
@@ -1,14 +1,18 @@
+# frozen_string_literal: true
+
 module ArbolFinanciero
   class Requestor
     attr_reader :api_key, :secret_key, :connection, :api_base
     def initialize
+      fail "ArbolFinanciero.configure has not been called!" unless ArbolFinanciero.configuration
+
       @api_key = ArbolFinanciero.configuration.api_key
       @secret_key = ArbolFinanciero.configuration.secret_key
-      @connection = ArbolFinanciero.configuration.connection
-      @api_base = self.class.join_url(ArbolFinanciero.configuration.api_base, ArbolFinanciero.configuration.api_version)
-      set_headers_for(connection)
       fail "Api key has not been set!" if @api_key.blank?
       fail "Secret key has not been set!" if @secret_key.blank?
+
+      @connection = ArbolFinanciero.configuration.connection
+      @api_base = self.class.join_url(ArbolFinanciero.configuration.api_base, ArbolFinanciero.configuration.api_version)
     end
 
     def self.join_url(url, path)
@@ -16,6 +20,7 @@ module ArbolFinanciero
     end
 
     def request(resource_url, http_method, params={})
+      set_headers_for(connection)
       response = connection.method(http_method).call do |request|
         request.url self.class.join_url(api_base, resource_url)
         set_request_params(request, params) if params.present?
@@ -26,7 +31,6 @@ module ArbolFinanciero
     private
 
       def set_headers_for(connection)
-        connection.headers['Host'] = 'application/json'
         connection.headers['x-api-key'] = api_key
         connection.headers['x-signature'] = signature
         connection.headers['Accept'] = "application/vnd.api+json"
@@ -40,7 +44,6 @@ module ArbolFinanciero
         digest = OpenSSL::Digest.new("sha1")
         OpenSSL::HMAC.hexdigest(digest, secret_key, raw_signature)
       end
-
 
       def set_request_params(request, params)
         case request.method

--- a/spec/arbol_financiero/requestor_spec.rb
+++ b/spec/arbol_financiero/requestor_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe ArbolFinanciero::Requestor do
+  before do
+    # This is needed because other tests may cause a configuration to be set.
+    ArbolFinanciero.class_exec { self.configuration = nil }
+  end
+
+  describe "#initialize" do
+    it "fails if no configuration block has been called" do
+      expect {
+        ArbolFinanciero::Requestor.new
+      }.to raise_error("ArbolFinanciero.configure has not been called!")
+    end
+
+    context "With configuration" do
+      it "fails if an api key is not configured" do
+        ArbolFinanciero.configure do |config|
+        end
+
+        expect {
+          ArbolFinanciero::Requestor.new
+        }.to raise_error("Api key has not been set!")
+      end
+
+      it "fails if a secret key is not configured" do
+        ArbolFinanciero.configure do |config|
+          config.api_key = "my_api_key"
+        end
+
+        expect {
+          ArbolFinanciero::Requestor.new
+        }.to raise_error("Secret key has not been set!")
+      end
+
+      it "does not fail if everything is configured" do
+        ArbolFinanciero.configure do |config|
+          config.api_key = "my_api_key"
+          config.secret_key = "my_secret_key"
+        end
+
+        expect {
+          ArbolFinanciero::Requestor.new
+        }.to_not raise_error
+      end
+    end
+  end
+
+  describe "#request" do
+    let(:response) { double(body: "{\"data\":{}}") }
+    let(:connection_double) {
+      double(get: response, headers: {}).as_null_object
+    }
+
+    before do
+      ArbolFinanciero.configure do |config|
+        config.api_key = "my_api_key"
+        config.secret_key = "my_secret_key"
+      end
+      ArbolFinanciero.configuration.connection = connection_double
+    end
+
+    subject { ArbolFinanciero::Requestor.new }
+
+    it "recomputes signature for each request" do
+      expect(subject).to receive(:set_headers_for).with(connection_double).twice
+      subject.request "folios/123", :get
+      subject.request "folios/124", :get
+    end
+
+    it "parses response" do
+      expect(subject.request("folios/124", :get)).to be_kind_of(Hash)
+    end
+  end
+end


### PR DESCRIPTION
El `signature` se debe recalcular cada vez que se realiza un request a la api. 